### PR TITLE
User Can Finalize Order/User Can View Order

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.7'
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)
@@ -61,6 +66,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -94,6 +101,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jsonapi-renderer (0.2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -217,6 +225,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.2)
   coveralls
   devise_token_auth

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -8,9 +8,14 @@ class Api::OrdersController < ApplicationController
 
   def update
     order = Order.find(params[:id])
-    product = Product.find(params[:product_id])
-    order.order_items.create(product: product)
-    render json: create_json_response(order)
+    if params[:activity]
+      order.update_attribute(:finalized, true)
+      render json: { message: 'Your order will be ready in 20 minutes' }
+    else
+      product = Product.find(params[:product_id])
+      order.order_items.create(product: product)
+      render json: create_json_response(order)
+    end
   end
 
   private

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -3,13 +3,20 @@ class Api::OrdersController < ApplicationController
   def create
     order = Order.create
     order.order_items.create(product_id: params[:product_id])
-    render json: { message: 'Product was successfully added to your order!', order_id: order.id }
+    render json: create_json_response(order)
   end
 
   def update
     order = Order.find(params[:id])
     product = Product.find(params[:product_id])
     order.order_items.create(product: product)
-    render json: {message: 'Updated product was successfully added to your order!', order_id: order.id}
+    render json: create_json_response(order)
+  end
+
+  private
+
+  def create_json_response(order)
+    json = { order: OrderSerializer.new(order) }
+    json.merge!(message: 'Product was successfully added to your order!')
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,7 @@
 class Order < ApplicationRecord
   has_many :order_items
+
+  def order_total
+    order_items.joins(:product).sum("products.price")
+  end
 end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,3 @@
+class OrderSerializer < ActiveModel::Serializer
+  attributes :id
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,5 +1,5 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id, :products, :total, :order_total
+  attributes :id, :products, :total, :order_total, :finalized
 
   def products
     object.order_items.group_by(&:product_id).map do |_key, value|

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,3 +1,14 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id
+  attributes :id, :products, :total, :order_total
+
+  def products
+    object.order_items.group_by(&:product_id).map do |_key, value|
+    product = value.uniq(&:product_id)[0].product
+    { amount: value.size, name: product.name, total: ( value.size * product.price )}
+    end
+  end
+
+  def total
+    object.order_items.joins(:product).sum('products.price')
+  end
 end

--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/db/migrate/20201129140522_add_finalized_to_orders.rb
+++ b/db/migrate/20201129140522_add_finalized_to_orders.rb
@@ -1,0 +1,5 @@
+class AddFinalizedToOrders < ActiveRecord::Migration[6.0]
+  def change
+    add_column :orders, :finalized, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_28_110152) do
+ActiveRecord::Schema.define(version: 2020_11_29_140522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_11_28_110152) do
   create_table "orders", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "finalized", default: false
   end
 
   create_table "products", force: :cascade do |t|

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :order do
-    user
+    user = :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { "user@mail.com" }
+    email { "superuser@mail.com" }
     password { "password" }
     password_confirmation { "password" }
   end

--- a/spec/requests/api/user_can_create_new_order_spec.rb
+++ b/spec/requests/api/user_can_create_new_order_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::OrdersController, type: :request do
   before do
     post '/api/orders', 
       params: { product_id: product_1.id }
-      @order_id = JSON.parse(response.body)["order"]["id"]
+      order_id = JSON.parse(response.body)["order"]["id"]
       @order = Order.find(order_id)
   end
 
@@ -36,8 +36,8 @@ RSpec.describe Api::OrdersController, type: :request do
 
   describe 'PUT/api/orders/:id' do
     before do
-      put "/api/orders/#{@order_id}", params: {product_id: product_2.id}
-      put "/api/orders/#{@order_id}", params: {product_id: product_2.id}
+      put "/api/orders/#{@order.id}", params: {product_id: product_2.id}
+      put "/api/orders/#{@order.id}", params: {product_id: product_2.id}
     end
 
     it 'adds another product to order if request is a PUT and param id of the order is present' do

--- a/spec/requests/api/user_can_create_new_order_spec.rb
+++ b/spec/requests/api/user_can_create_new_order_spec.rb
@@ -1,43 +1,59 @@
 RSpec.describe Api::OrdersController, type: :request do
-  let!(:product_1) { create(:product, name: 'Swedish Meatballs') }
-  let!(:product_2) { create(:product, name: 'Reindeer Tartare') }
+  let!(:product_1) { create(:product, name: 'Swedish Meatballs', price: 10) }
+  let!(:product_2) { create(:product, name: 'Reindeer Tartare', price: 15) }
   #let!(:registered_user) { create(:user) }
   #let!(:authorization_headers) { registered_user.create_new_auth_token }
 
   before do
     post '/api/orders', 
       params: { product_id: product_1.id }
-      @order_id = JSON.parse(response.body)['order_id']
+      @order_id = JSON.parse(response.body)["order"]["id"]
+      @order = Order.find(order_id)
   end
 
-  describe 'POST/api/orders'do
+  describe 'POST/api/orders' do
+    it {
+      expect(response).to have_http_status 200
+    }
+
     it 'is expected to respond with a success message' do
       expect(JSON.parse(response.body)['message'])
       .to eq 'Product was successfully added to your order!'
     end
 
     it 'responds with order id' do
-      order = Order.find(@order_id)
-      expect(JSON.parse(response.body)['order_id']).to eq order.id
-    end
-  
-    it {
-      expect(response).to have_http_status 200
-    }
+      expect(JSON.parse(response.body)["order"]["id"]).to eq @order.id
     end
 
-  describe 'PUT/api/orders/:id'do
+    it 'responds with right amount of products' do
+      expect(JSON.parse(response.body)["order"]["products"].count).to eq 1
+    end
+
+    it 'responds with right order total price' do
+      expect(JSON.parse(response.body)["order"]["total"]).to eq 10
+    end
+  end
+
+  describe 'PUT/api/orders/:id' do
     before do
       put "/api/orders/#{@order_id}", params: {product_id: product_2.id}
-      @order = Order.find(@order_id)
+      put "/api/orders/#{@order_id}", params: {product_id: product_2.id}
     end
 
-    it 'adds another product to order if param "order_id" is present' do
-      expect(@order.order_items.count).to eq 2
+    it 'adds another product to order if request is a PUT and param id of the order is present' do
+      expect(@order.order_items.count).to eq 3
     end
 
     it 'responds with order id' do
-      expect(JSON.parse(response.body)['order_id']).to eq @order.id
+      expect(JSON.parse(response.body)["order"]["id"]).to eq @order.id
+    end
+
+    it 'responds with right amount of unique products' do
+      expect(JSON.parse(response.body)["order"]["products"].count).to eq 2
+    end
+
+    it 'responds with right order total price' do
+      expect(JSON.parse(response.body)["order"]["total"]).to eq 40
     end
   end
 end

--- a/spec/requests/api/user_can_finalize_order_spec.rb
+++ b/spec/requests/api/user_can_finalize_order_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe Api::OrdersController, type: :request do
   let!(:product_1) { create(:product, name: 'Swedish Meatballs', price: 10) }
   let!(:product_2) { create(:product, name: 'Reindeer Tartate', price: 15) }
-  # let(:order) { create(:order, :user) }
-  # let(:registered_user) { create(:user) }
   let(:order) { create(:order) }
 
   before do

--- a/spec/requests/api/user_can_finalize_order_spec.rb
+++ b/spec/requests/api/user_can_finalize_order_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Api::OrdersController, type: :request do
+  let!(:product_1) { create(:product, name: 'Swedish Meatballs', price: 10) }
+  let!(:product_2) { create(:product, name: 'Reindeer Tartate', price: 15) }
+  # let(:order) { create(:order, :user) }
+  # let(:registered_user) { create(:user) }
+  let(:order) { create(:order) }
+
+  before do
+    order.order_items.create(product: product_1)
+    order.order_items.create(product: product_2)
+    
+    put "/api/orders/#{order.id}", params: { activity: 'finalize' }
+  end
+
+  describe 'PUT /api/orders request' do
+    it 'is expected to respond with a success message' do
+      expect(JSON.parse(response.body)['message']).to eq 'Your order will be ready in 20 minutes'
+    end
+
+    it 'is expected to set the order attribute \'finalized\' to true' do
+      expect(order.reload.finalized).to eq true 
+    end
+  end
+end


### PR DESCRIPTION
[API provides functionality to finalize order/API provides functionality for user to see their current order](https://www.pivotaltracker.com/n/projects/2477606)
### User Story View
```
As a restaurant API
In order to give the user a way to see their current order
I would like to serve the client with the current pending order for that user
```
### User Story Finalize 
```
As a restaurant API
In order for the user to complete their order
I would like to be able to update their existing order to be finalized
```
## Changes proposed in this pull request:
* Adds `orders` serializer 
* Creates `create_json_response` function in `orders` controller
* Adds `order_total` method in `order` model
* Adds `products`, `total` methods to `order_serializer`
* Adds `finalized` attribute to `order_serializer`
* Refactors `update` action in `orders` controller to return success message upon finalization 
* Adds `finalized` attribute in `orders` DB (migrate)
## What I have learned working on this feature:
* How a serializer maps over keys and values to create (in this case) an order that can be updated
## Packages/Gems added
* `'gem active_model_serializers'`

